### PR TITLE
FB link fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
                 <ul class="nav masthead-nav">
                   <li class="active"><a href="#">Home</a></li>
                   <li><a href="https://medium.com/philosophy-of-computation-at-berkeley">Blog</a></li>
-                  <li><a href="facebook.com/berkeleypoc">Facebook</a></li>
+                  <li><a href="https://facebook.com/berkeleypoc">Facebook</a></li>
                 </ul>
               </nav>
 


### PR DESCRIPTION
FB Link is broken-- current link attempts to go to https://pocab.github.io/facebook.com/berkeleypoc. This should fix that.